### PR TITLE
Allow using FontAwesome free / pro via `_config.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ and name as word(s).
   Drop a file called `title.html` in the root of your site.
   In its contents you can go as simple as `{{ site.name }}`
   and as complex as a custom SVG shape.
-  
+
   Note that it must look good when placed inside ~30px tall container.
   In case of SVG, SVG guidelines apply.
-  
+
 Do not create custom CSS rules for .site-logo descendants:
 this may cause issues when one site’s logo is used in context of another site
 of the same hub. You can use inline styling, though.
@@ -346,6 +346,13 @@ parent_hub:
 algolia_search:
   api_key: '<your Algolia API key>'
   index_name: '<your Algolia index name>'
+
+# Add this if you want to use Font Awesome Pro (the paid version).
+icon_font:
+  icon_class: 'far'
+  fa_integrity: 'sha384-E5SpgaZcbSJx0Iabb3Jr2AfTRiFnrdOw1mhO19DzzrT9L+wCpDyHUG2q07aQdO6E'
+  fa_src: https://pro.fontawesome.com/releases/v5.1.0/js/all.js
+
 # Only add this if you want to use Algolia’s search on your project site.
 
 tag_namespaces:
@@ -508,7 +515,7 @@ external_links:
 #   GitHub, Docs.rs, RubyDoc,
 #   ietf.org/html/rfcN, datatracker.ietf.org/doc/…
 # * Order links according to importance for project site visitors.
-#   The first link will be highlighted as primary. 
+#   The first link will be highlighted as primary.
 
 feature_with_priority: 1
 # With this key, software or spec will be featured on home
@@ -695,7 +702,7 @@ Commonly used layouts are:
 
 ### Page frontmatter
 
-Typical expected page frontmatter is `title` and `description`. Those are 
+Typical expected page frontmatter is `title` and `description`. Those are
 also used by jekyll-seo-tag plugin to add the appropriate meta tags.
 
 Commonly supported in page frontmatter is the hero_include option,
@@ -817,7 +824,7 @@ run `bundle install`.
 
 To experiment with this code, add content (projects, software, specs)
 and run `bundle exec jekyll serve`. This starts a Jekyll server
-using this theme at `http://localhost:4000`. 
+using this theme at `http://localhost:4000`.
 
 Put your layouts in `_layouts`, your includes in `_includes`,
 your sass files in `_sass` and any other assets in `assets`.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ These settings apply to both site types (hub and project).
     tos_link: https://www.example.com/tos
     privacy_policy_link: https://www.example.com/privacy
 
-  # These are required for the theme to work:
-  # disable_fontawesome_cdn: yes
+  # no_auto_fontawesome: yes
   # Specify this only if you want to disable free Font Awesome CDN.
   # IMPORTANT: In this case your site MUST specify include head.html with appropriate scripts.
   # Theme design relies on Font Awesome “solid” and “brands” icon styles

--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ These settings apply to both site types (hub and project).
     privacy_policy_link: https://www.example.com/privacy
 
   # These are required for the theme to work:
+  # disable_fontawesome_cdn: yes
+  # Specify this only if you want to disable free Font Awesome CDN.
+  # IMPORTANT: In this case your site MUST specify include head.html with appropriate scripts.
+  # Theme design relies on Font Awesome “solid” and “brands” icon styles
+  # and expects them to be included in SVG mode.
+  # Without this setting, one-file FA distribution, all.js, is included from free FA CDN.
 
   theme: jekyll-theme-open-project
   permalink: /blog/:month-:day-:year/:title/
@@ -346,12 +352,6 @@ parent_hub:
 algolia_search:
   api_key: '<your Algolia API key>'
   index_name: '<your Algolia index name>'
-
-# Add this if you want to use Font Awesome Pro (the paid version).
-icon_font:
-  icon_class: 'far'
-  fa_integrity: 'sha384-E5SpgaZcbSJx0Iabb3Jr2AfTRiFnrdOw1mhO19DzzrT9L+wCpDyHUG2q07aQdO6E'
-  fa_src: https://pro.fontawesome.com/releases/v5.1.0/js/all.js
 
 # Only add this if you want to use Algolia’s search on your project site.
 

--- a/_config.yml
+++ b/_config.yml
@@ -41,10 +41,14 @@ collections:
     output: true
     permalink: /:name/
 
-icon_font:
-  icon_class: 'fas'
-  fa_integrity: 'sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ'
-  fa_src: https://use.fontawesome.com/releases/v5.8.1/js/all.js
+disable_fontawesome_cdn: no
+# If set to yes, site (with default design) must specify <script> elements
+# that make required FA styles available in SVG mode.
+
+fontawesome_cdn:
+  version: v5.8.1
+  integrity: "sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ" 
+
 
 defaults:
   - scope:

--- a/_config.yml
+++ b/_config.yml
@@ -41,13 +41,14 @@ collections:
     output: true
     permalink: /:name/
 
-disable_fontawesome_cdn: no
-# If set to yes, site (with default design) must specify <script> elements
-# that make required FA styles available in SVG mode.
-
 fontawesome_cdn:
   version: v5.8.1
   integrity: "sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ" 
+# Only applies if no_auto_fontawesome is not set.
+
+no_auto_fontawesome: false
+# If set to yes, site (with default design) must specify <script> elements
+# that make required FA styles available in SVG mode.
 
 
 defaults:

--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,11 @@ collections:
     output: true
     permalink: /:name/
 
+icon_font:
+  icon_class: 'fas'
+  fa_integrity: 'sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ'
+  fa_src: https://use.fontawesome.com/releases/v5.8.1/js/all.js
+
 defaults:
   - scope:
       path: ""

--- a/_includes/external-link.html
+++ b/_includes/external-link.html
@@ -10,7 +10,7 @@
 
   {% elsif include.url contains "rubygems.org" %}
     <span class="ico">
-      <i class="far fa-gem"></i>
+      <i class="{{ site.icon_font.icon_class }} fa-gem"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "Gem" }}
@@ -18,7 +18,7 @@
 
   {% elsif include.url contains "crates.io/crates" %}
     <span class="ico">
-      <i class="far fa-cubes"></i>
+      <i class="{{ site.icon_font.icon_class }} fa-cubes"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "Crate" }}
@@ -26,7 +26,7 @@
 
   {% elsif include.url contains "rubydoc" %}
     <span class="ico">
-      <i class="far fa-gem"></i>
+      <i class="{{ site.icon_font.icon_class }} fa-gem"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "RubyDoc" }}
@@ -34,7 +34,7 @@
 
   {% elsif include.url contains "docs.rs" %}
     <span class="ico">
-      <i class="far fa-book"></i>
+      <i class="{{ site.icon_font.icon_class }} fa-book"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "Docs.rs" }}

--- a/_includes/external-link.html
+++ b/_includes/external-link.html
@@ -10,7 +10,7 @@
 
   {% elsif include.url contains "rubygems.org" %}
     <span class="ico">
-      <i class="{{ site.icon_font.icon_class }} fa-gem"></i>
+      <i class="fas fa-gem"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "Gem" }}
@@ -18,7 +18,7 @@
 
   {% elsif include.url contains "crates.io/crates" %}
     <span class="ico">
-      <i class="{{ site.icon_font.icon_class }} fa-cubes"></i>
+      <i class="fas fa-cubes"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "Crate" }}
@@ -26,7 +26,7 @@
 
   {% elsif include.url contains "rubydoc" %}
     <span class="ico">
-      <i class="{{ site.icon_font.icon_class }} fa-gem"></i>
+      <i class="fas fa-gem"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "RubyDoc" }}
@@ -34,7 +34,7 @@
 
   {% elsif include.url contains "docs.rs" %}
     <span class="ico">
-      <i class="{{ site.icon_font.icon_class }} fa-book"></i>
+      <i class="fas fa-book"></i>
     </span>
     <span class="lbl">
       {{ include.title | default: "Docs.rs" }}

--- a/_includes/home-hero.html
+++ b/_includes/home-hero.html
@@ -8,7 +8,7 @@
   {% if site.is_hub %}
     <div class="cta">
       <a class="button" href="{{ "/projects/" | relative_url }}">
-        <i class="icon fas fa-search"></i>
+        <i class="icon {{ site.icon_font.icon_class }} fa-search"></i>
         Explore Projects
       </a>
     </div>

--- a/_includes/home-hero.html
+++ b/_includes/home-hero.html
@@ -8,7 +8,7 @@
   {% if site.is_hub %}
     <div class="cta">
       <a class="button" href="{{ "/projects/" | relative_url }}">
-        <i class="icon {{ site.icon_font.icon_class }} fa-search"></i>
+        <i class="icon fas fa-search"></i>
         Explore Projects
       </a>
     </div>

--- a/_includes/item-doc-page.html
+++ b/_includes/item-doc-page.html
@@ -47,8 +47,8 @@ supporting expandable navigation widget.
 
       {% if num_top_nav_items > 0 %}
         <span class="nav-toggle-icon">
-          <i class="open {{ site.icon_font.icon_class }} fa-ellipsis-v"></i>
-          <i class="close {{ site.icon_font.icon_class }} fa-times"></i>
+          <i class="open fas fa-ellipsis-v"></i>
+          <i class="close fas fa-times"></i>
         </span>
       {% endif %}
     </div>
@@ -66,7 +66,7 @@ supporting expandable navigation widget.
             <li class="item home-link" title="Documentation index">
               <a href="{{ product_base_url | relative_url }}">
                 <span class="ico">
-                  <i class="{{ site.icon_font.icon_class }} fa-home"></i>
+                  <i class="fas fa-home"></i>
                 </span>
                 <span class="lbl">
                   Home

--- a/_includes/item-doc-page.html
+++ b/_includes/item-doc-page.html
@@ -47,8 +47,8 @@ supporting expandable navigation widget.
 
       {% if num_top_nav_items > 0 %}
         <span class="nav-toggle-icon">
-          <i class="open far fa-ellipsis-v"></i>
-          <i class="close far fa-times"></i>
+          <i class="open {{ site.icon_font.icon_class }} fa-ellipsis-v"></i>
+          <i class="close {{ site.icon_font.icon_class }} fa-times"></i>
         </span>
       {% endif %}
     </div>
@@ -66,7 +66,7 @@ supporting expandable navigation widget.
             <li class="item home-link" title="Documentation index">
               <a href="{{ product_base_url | relative_url }}">
                 <span class="ico">
-                  <i class="far fa-home"></i>
+                  <i class="{{ site.icon_font.icon_class }} fa-home"></i>
                 </span>
                 <span class="lbl">
                   Home

--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -41,5 +41,5 @@
 {% endif %}
 
 {% if site.algolia_search %}
-  <a href="javascript: void 0;" class="search"><i class="{{ site.icon_font.icon_class }} fa-search"></i></a>
+  <a href="javascript: void 0;" class="search"><i class="fas fa-search"></i></a>
 {% endif %}

--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -41,5 +41,5 @@
 {% endif %}
 
 {% if site.algolia_search %}
-  <a href="javascript: void 0;" class="search"><i class="fas fa-search"></i></a>
+  <a href="javascript: void 0;" class="search"><i class="{{ site.icon_font.icon_class }} fa-search"></i></a>
 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
 
   <link id="themeCSS" rel="stylesheet" href="{{ "assets/css/style.css" | relative_url }}">
 
-  {% unless site.disable_fontawesome_cdn %}
+  {% unless site.no_auto_fontawesome %}
     <script
       defer
       src="https://use.fontawesome.com/releases/{{ site.fontawesome_cdn.version }}/js/all.js"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,13 @@
 
   <link id="themeCSS" rel="stylesheet" href="{{ "assets/css/style.css" | relative_url }}">
 
-  <script defer src="{{ site.icon_font.fa_src }}" integrity="{{ site.icon_font.fa_integrity }}" crossorigin="anonymous"></script>
+  {% unless site.disable_fontawesome_cdn %}
+    <script
+      defer
+      src="https://use.fontawesome.com/releases/{{ site.fontawesome_cdn.version }}/js/all.js"
+      integrity="{{ site.fontawesome_cdn.integrity }}"
+      crossorigin="anonymous"></script>
+  {% endunless %}
 
   {% if site.algolia_search %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
@@ -29,6 +35,8 @@
   {% endif %}
 
   {% seo %}
+
+  {% include head.html %}
 </head>
 
 {% assign num_projects = site.projects | size %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,11 +10,7 @@
 
   <link id="themeCSS" rel="stylesheet" href="{{ "assets/css/style.css" | relative_url }}">
 
-  {% if site.use_fa_pro %}
-  <script defer src="https://pro.fontawesome.com/releases/{{ site.fa_pro_version }}/js/all.js" integrity="{{ site.fa_pro_hash }}" crossorigin="anonymous"></script>
-  {% else %}
-  <script defer src="https://use.fontawesome.com/releases/v5.8.1/js/all.js" integrity="sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ" crossorigin="anonymous"></script>
-  {% endif %}
+  <script defer src="{{ site.icon_font.fa_src }}" integrity="{{ site.icon_font.fa_integrity }}" crossorigin="anonymous"></script>
 
   {% if site.algolia_search %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
@@ -104,14 +100,14 @@
     {% endcomment %}
     <script>
       window.initAlgolia = function () {
-        docsearch({ 
-          apiKey: '{{ site.algolia_search.api_key }}', 
-          indexName: '{{ site.algolia_search.index_name }}', 
-          inputSelector: 'input[type=search]', 
+        docsearch({
+          apiKey: '{{ site.algolia_search.api_key }}',
+          indexName: '{{ site.algolia_search.index_name }}',
+          inputSelector: 'input[type=search]',
           debug: false,
-        }); 
+        });
       };
-    </script> 
+    </script>
   {% endif %}
 
   <script src="{{ "assets/js/headroom.min.js" | relative_url }}"></script>

--- a/_layouts/docs-base.html
+++ b/_layouts/docs-base.html
@@ -24,8 +24,8 @@ layout: default
 
     {% if num_top_nav_items > 0 %}
       <span class="nav-toggle-icon">
-        <i class="open far fa-ellipsis-v"></i>
-        <i class="close far fa-times"></i>
+        <i class="open {{ site.icon_font.icon_class }} fa-ellipsis-v"></i>
+        <i class="close {{ site.icon_font.icon_class }} fa-times"></i>
       </span>
     {% endif %}
   </div>

--- a/_layouts/docs-base.html
+++ b/_layouts/docs-base.html
@@ -24,8 +24,8 @@ layout: default
 
     {% if num_top_nav_items > 0 %}
       <span class="nav-toggle-icon">
-        <i class="open {{ site.icon_font.icon_class }} fa-ellipsis-v"></i>
-        <i class="close {{ site.icon_font.icon_class }} fa-times"></i>
+        <i class="open fas fa-ellipsis-v"></i>
+        <i class="close fas fa-times"></i>
       </span>
     {% endif %}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -26,7 +26,7 @@ layout: default
       {% for link in page.author.social_links %}
         <a href="{{ link }}" class="ico">
           <span class="fa-layers fa-2x">
-            <i class="fas fa-circle"></i>
+            <i class="{{ site.icon_font.icon_class }} fa-circle"></i>
             <i
               {% if link contains "twitter.com" %}
                 class="fab fa-twitter"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -26,7 +26,7 @@ layout: default
       {% for link in page.author.social_links %}
         <a href="{{ link }}" class="ico">
           <span class="fa-layers fa-2x">
-            <i class="{{ site.icon_font.icon_class }} fa-circle"></i>
+            <i class="fas fa-circle"></i>
             <i
               {% if link contains "twitter.com" %}
                 class="fab fa-twitter"


### PR DESCRIPTION
This is a clean up (and follow up) of #65 .

I've extracted out these variables to be determined in `_config.yml`:
* Icon font URL
* Icon font integrity hash
* FontAwesome Icon class (`far` or `fas`)

By default, they are set to this in the gem's `_config.yml`:
```yaml
icon_font:
  icon_class: 'fas'
  fa_integrity: 'sha384-g5uSoOSBd7KkhAMlnQILrecXvzst9TdC09/VM+pjDTCM+1il8RHz5fKANTFFb+gQ'
  fa_src: https://use.fontawesome.com/releases/v5.8.1/js/all.js
```

If you want to use pro (e.g. in relaton.com), we set `_config.yml` in the "user site" (i.e. relaton.com) to:
```yaml
icon_font:
  icon_class: 'far'
  fa_integrity: 'sha384-E5SpgaZcbSJx0Iabb3Jr2AfTRiFnrdOw1mhO19DzzrT9L+wCpDyHUG2q07aQdO6E'
  fa_src: https://pro.fontawesome.com/releases/v5.1.0/js/all.js
```

@strogonoff please help review (I've tried it with relaton.com, and it worked). Thanks!