### PR TITLE
Added reusable button for tutorials

### DIFF
--- a/_includes/next-lesson-button.html
+++ b/_includes/next-lesson-button.html
@@ -1,0 +1,1 @@
+<a href="https://metanorma.org/{{ include.url }}"><button class="button tutorial">{{ include.content }}</button></a>

--- a/_includes/next-lesson-button.html
+++ b/_includes/next-lesson-button.html
@@ -1,1 +1,1 @@
-<a href="https://metanorma.org/{{ include.url }}"><button class="button tutorial">{{ include.content }}</button></a>
+<a href="{{ include.url }}"><button class="button tutorial">{{ include.content }}</button></a>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -11,3 +11,22 @@ $main-background: linear-gradient(135deg, #0446CC 0%, #2864DD 100%);
 .site-logo svg path {
   fill: white;
 }
+
+// Button styling for _includes/next-lesson-button.html
+.button {
+	display: inline-block;
+	border-radius: 25px;
+	background-color: #6352adff;
+	border: none;
+	color: #FFFFFF;
+	text-align: center;
+	font-size: 20px;
+	padding: 20px;
+	width: 210px;
+	transition: all 0.5s;
+	cursor: pointer;
+	margin: 5px;
+	&:hover {
+		background-color: #48409cff;
+	}
+}


### PR DESCRIPTION
I'm currently working on our tutorial content to get it published. 
Instead of just providing a link to the next lesson, I wanted to make the action item clearer and use a button, like this: 
![image](https://user-images.githubusercontent.com/13576110/148698884-22db058d-1551-47e7-a80d-4ac366191957.png)
In order to do that, I need a button in the _includes folder.
